### PR TITLE
Update mock and test for Alert Events V2

### DIFF
--- a/test/alert_events_v2_test.exs
+++ b/test/alert_events_v2_test.exs
@@ -25,14 +25,14 @@ defmodule IncidentIo.AlertEventsV2Test do
 
     test "returns expected HTTP status code" do
       use_cassette "alert_events_v2#create" do
-        assert {202, _, _} = create(@client, "some-alert-source-config-id", "some-token", @body)
+        assert {202, _, _} = create(@client, "01GW2G3V0S59R238FAHPDS1R66", "some-token", @body)
       end
     end
 
     test "returns expected attributes for action" do
       use_cassette "alert_events_v2#create" do
         {202, %{deduplication_key: deduplication_key, message: message, status: status}, _} =
-          create(@client, "some-alert-source-config-id", "some-token", @body)
+          create(@client, "01GW2G3V0S59R238FAHPDS1R66", "some-token", @body)
 
         assert deduplication_key == "unique-key"
         assert message == "Event accepted for processing"

--- a/test/fixture/vcr_cassettes/alert_events_v2#create.json
+++ b/test/fixture/vcr_cassettes/alert_events_v2#create.json
@@ -11,7 +11,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://api.incident.io/v2/alert_events/http/some-alert-source-config-id?token=some-token"
+      "url": "https://api.incident.io/v2/alert_events/http/01GW2G3V0S59R238FAHPDS1R66?token=some-token"
     },
     "response": {
       "binary": false,


### PR DESCRIPTION
💁 These changes update the existing mock fixture and test to use example data from the [OpenAPI schema for Incident's API](https://api-docs.incident.io/).