### PR TITLE
CI: remove `github-token` from Coveralls action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
       run: mix coveralls.lcov
     - name: Upload coverage reports to Coveralls
       uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   credo:
     name: Static analysis (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})


### PR DESCRIPTION
💁 According to the [documentation for `coverallsapp/github-action`](https://github.com/coverallsapp/github-action/blob/v2.3.0/README.md#inputs), this change should be fine.