### PR TITLE
Fix: Update expectations in test case for `SchedulesV2.create/2`

### DIFF
--- a/test/fixture/vcr_cassettes/schedules#create.json
+++ b/test/fixture/vcr_cassettes/schedules#create.json
@@ -33,7 +33,7 @@
         "Via": "1.1 google",
         "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
       },
-      "status_code": 200,
+      "status_code": 201,
       "type": "ok"
     }
   }

--- a/test/schedules_v2_test.exs
+++ b/test/schedules_v2_test.exs
@@ -154,13 +154,13 @@ defmodule IncidentIo.SchedulesV2Test do
 
     test "returns expected HTTP status code" do
       use_cassette "schedules#create" do
-        assert {200, _, _} = create(@client, @body)
+        assert {201, _, _} = create(@client, @body)
       end
     end
 
     test "returns expected response" do
       use_cassette "schedules#create" do
-        {200, response, _} = create(@client, @body)
+        {201, response, _} = create(@client, @body)
 
         assert %{
                  schedule: %{


### PR DESCRIPTION
💁 These changes fix some incorrect expectations used in the test case for `SchedulesV2.create/2`.