### PR TITLE
CI: Publish new package versions automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,17 @@ jobs:
     name: Coverage (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        otp: ['26']
-        elixir: ['1.16']
-
     env:
       MIX_ENV: test
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
+      id: setup-beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{matrix.elixir}}
-        otp-version: ${{matrix.otp}}
+        version-file: '.tool-versions'
+        version-type: 'strict'
     - name: Cache dependencies
       id: cache-deps
       uses: actions/cache@v4
@@ -36,8 +32,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only test, deps.compile
@@ -52,21 +48,17 @@ jobs:
     name: Static analysis (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        otp: ['26']
-        elixir: ['1.16']
-
     env:
       MIX_ENV: test
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
+      id: setup-beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{matrix.elixir}}
-        otp-version: ${{matrix.otp}}
+        version-file: '.tool-versions'
+        version-type: 'strict'
     - name: Cache dependencies
       id: cache-deps
       uses: actions/cache@v4
@@ -74,8 +66,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only test, deps.compile
@@ -131,21 +123,17 @@ jobs:
     name: Validate code (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        otp: ['26']
-        elixir: ['1.16']
-
     env:
       MIX_ENV: test
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
+      id: setup-beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{matrix.elixir}}
-        otp-version: ${{matrix.otp}}
+        version-file: '.tool-versions'
+        version-type: 'strict'
     - name: Cache dependencies
       id: cache-deps
       uses: actions/cache@v4
@@ -153,8 +141,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only test, deps.compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,36 @@ jobs:
     - name: Run static analysis
       run: mix credo
 
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: test
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        version-file: '.tool-versions'
+        version-type: 'strict'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: mix do deps.get --only test, deps.compile
+    - name: Check code format
+      run: mix format --check-formatted
+
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
@@ -118,33 +148,3 @@ jobs:
       run: mix compile
     - name: Run tests
       run: mix test
-
-  validate:
-    name: Validate code
-    runs-on: ubuntu-latest
-
-    env:
-      MIX_ENV: test
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Elixir
-      id: setup-beam
-      uses: erlef/setup-beam@v1
-      with:
-        version-file: '.tool-versions'
-        version-type: 'strict'
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          _build
-          deps
-        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only test, deps.compile
-    - name: Check code format
-      run: mix format --check-formatted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   coverage:
-    name: Coverage (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
+    name: Coverage (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
     runs-on: ubuntu-latest
 
     env:
@@ -45,7 +45,7 @@ jobs:
       uses: coverallsapp/github-action@v2
 
   credo:
-    name: Static analysis (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
+    name: Static analysis (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
     runs-on: ubuntu-latest
 
     env:
@@ -77,7 +77,7 @@ jobs:
       run: mix credo
 
   test:
-    name: Tests (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
+    name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -120,7 +120,7 @@ jobs:
       run: mix test
 
   validate:
-    name: Validate code (Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}})
+    name: Validate code (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   coverage:
-    name: Coverage (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
+    name: Coverage
     runs-on: ubuntu-latest
 
     env:
@@ -45,7 +45,7 @@ jobs:
       uses: coverallsapp/github-action@v2
 
   credo:
-    name: Static analysis (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
+    name: Static analysis
     runs-on: ubuntu-latest
 
     env:
@@ -120,7 +120,7 @@ jobs:
       run: mix test
 
   validate:
-    name: Validate code (Elixir ${{ steps.setup-beam.elixir-version }} / OTP ${{ steps.setup-beam.otp-version }})
+    name: Validate code
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,5 @@ jobs:
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only test, deps.compile
-    - name: Compile code
-      run: mix compile
     - name: Check code format
       run: mix format --check-formatted

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
       id: setup-beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.16'
-        otp-version: '26'
+        version-file: '.tool-versions'
+        version-type: 'strict'
     - uses: actions/cache@v4
       id: cache-build
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+        name: ${{ github.ref_name }}
+
+  publish:
+    name: Publish Hex Package
+    runs-on: ubuntu-latest
+
+    needs: ["release"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: '1.16'
+        otp-version: '26'
+    - uses: actions/cache@v4
+      id: cache-build
+      with:
+        path: _build
+        key: publish-build-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: publish-build-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+    - uses: actions/cache@v4
+      id: cache-deps
+      with:
+        path: deps
+        key: publish-deps-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: publish-deps-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+    - name: Fetch and install dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: mix do deps.get, deps.compile
+    - name: Publish Hex package
+      run: mix hex.publish --yes
+      env:
+        HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.16-otp-26
+erlang 26.2.5.1


### PR DESCRIPTION
💁 These changes:
* add a new Actions workflow that performs the following jobs when a new git tag is pushed:
  1. create a new release with release notes
  2. build and push a new package version to Hex.pm
* change inline versioning for Elixir and Erlang/OTP in favour of declaring them in an [asdf](https://asdf-vm.com/) configuration file and using that.