### PR TITLE
CI: Develop and test with Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,15 @@ jobs:
     strategy:
       matrix:
         otp: ['24', '25', '26', '27']
-        elixir: ['1.15', '1.16', '1.17']
+        elixir: ['1.15', '1.16', '1.17', '1.18']
         exclude:
           - elixir: '1.15'
             otp: '27'
           - elixir: '1.16'
             otp: '27'
           - elixir: '1.17'
+            otp: '24'
+          - elixir: '1.18'
             otp: '24'
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,6 @@ jobs:
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only test, deps.compile
     - name: Compile code
-      run: mix compile
+      run: mix compile --warnings-as-errors
     - name: Run tests
-      run: mix test
+      run: mix test --warnings-as-errors

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17-otp-27
+elixir 1.18-otp-27
 erlang 27.2


### PR DESCRIPTION
💁 These changes introduce Elixir 1.18:
- adds this new version to the test matrix.
- updates the version in `.tool-versions` for local development.