### PR TITLE
Reduce permissions of publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
 
     needs: ["release"]
 
+    permissions: {}
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir


### PR DESCRIPTION
💁 While the release job needs to be able to create a release in the project, the publish job only needs to build and publish the package to Hex so doesn't need any GitHub API permissions.