### PR TITLE
Dependabot: conventional commit message format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,19 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
💁 These changes configure Dependabot to make their commit messages compatible with the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).