### PR TITLE
chore: Build new releases with Release Please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,30 +6,12 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v2
-      with:
-        draft: false
-        prerelease: false
-        generate_release_notes: true
-        name: ${{ github.ref_name }}
-
   publish:
     name: Publish Hex Package
     runs-on: ubuntu-latest
 
-    needs: ["release"]
-
-    permissions: {}
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Release Please
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          release-type: elixir


### PR DESCRIPTION
💁 These changes update the existing GitHub Actions workflows to use [Release Please](https://github.com/googleapis/release-please-action) for automatically building new releases. Publishing a new release will still use the existing [publish workflow](../blob/main/.github/workflows/publish.yml).