### PR TITLE
chore(package): Remove pre-release version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule IncidentIo.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/sgerrand/ex_incident_io"
-  @version "0.1.0-dev"
+  @version "0.1.0"
 
   def project do
     [


### PR DESCRIPTION
💁 The pre-release version component isn't currently needed so this change removes it.