### PR TITLE
ci: group Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,22 +2,40 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     cooldown:
-      default-days: 4
+      default-days: 7
     commit-message:
-      prefix: "fix"
-      include: "scope"
-  - package-ecosystem: "mix"
-    directory: "/"
+      prefix: ci
+      include: scope
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: mix
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     cooldown:
-      default-days: 4
+      default-days: 7
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      elixir:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
💁 These changes configure Dependabot to:

- group updates by package ecosystem
- also group security updates
- use different commit message prefixes per environment
- extend cooldown period from 4 days to 7