### PR TITLE
build: release-please version markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ With just a few lines of code you can begin interacting:
 
 ```elixir
 Mix.install([
-  {:incident_io, "~> 0.1"}
+  {:incident_io, "~> 0.1.1"}
 ])
 
 client = IncidentIo.Client.new(%{api_key: System.fetch_env!("INCIDENT_API_KEY")})

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Elixir client for the [incident.io API](https://api-docs.incident.io/).
 
 With just a few lines of code you can begin interacting:
 
+<!-- x-release-please-start-version -->
 ```elixir
 Mix.install([
   {:incident_io, "~> 0.1.1"}
@@ -19,6 +20,7 @@ IncidentIo.IncidentsV2.create(client,
                               idempotency_key: "your-idempotency-key",
                               visibility: :public)
 ```
+<!-- x-release-please-end -->
 
 ## Requirements
 


### PR DESCRIPTION
💁 These changes extend the existing Release Please configuration by wrapping the `incident_io` dep with `x-release-please-start-version` and `x-release-please-end markers` so the [generic extra-file updater can locate and bump the version on each release](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files). Corrects the constraint from ~> 0.1 to ~> 0.1.1 to match the current release.