### PR TITLE
build: add mix credo to pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,9 @@
 pre-commit:
   parallel: true
   commands:
+    mix-credo:
+      glob: "*.{ex,exs}"
+      run: mix credo --strict
     mix-format:
       glob: "*.{ex,exs}"
       run: mix format --check-formatted


### PR DESCRIPTION
💁 These changes add `mix credo` to the existing pre-commit hooks.