### PR TITLE
fix(open_api_v1): use caller-provided client

### DIFF
--- a/lib/incident_io/open_api_v1.ex
+++ b/lib/incident_io/open_api_v1.ex
@@ -18,7 +18,7 @@ defmodule IncidentIo.OpenApiV1 do
   More information at: https://api-docs.incident.io/tag/Utilities-V1#operation/Utilities%20V1_OpenAPIV3
   """
   @spec show(Client.t(), pos_integer) :: IncidentIo.response()
-  def show(_client \\ %Client{}, open_api_version \\ 3) do
+  def show(client \\ %Client{}, open_api_version \\ 3) do
     filename =
       case open_api_version do
         3 -> "openapiV3.json"
@@ -27,7 +27,7 @@ defmodule IncidentIo.OpenApiV1 do
 
     get(
       "v1/#{filename}",
-      %Client{}
+      client
     )
   end
 end


### PR DESCRIPTION
## Summary

- `OpenApiV1.show/2` accepted a `client` parameter but silently discarded it, always making requests with an unauthenticated `%Client{}`
- Any API key set by the caller was ignored
- Fix: pass `client` through to `get/2` instead of constructing a fresh blank client

## Test plan

- [x] Existing `open_api_v1_test.exs` tests pass (`mix test test/open_api_v1_test.exs`)