### PR TITLE
fix(catalog_entry_v2): correct typespec referencing nonexistent module

### DIFF
--- a/lib/incident_io/catalog_entry_v2.ex
+++ b/lib/incident_io/catalog_entry_v2.ex
@@ -163,7 +163,7 @@ defmodule IncidentIo.CatalogEntryV2 do
 
   More information at: https://api-docs.incident.io/tag/Catalog-V2#operation/Catalog%20V2_UpdateEntry
   """
-  @spec update(Client.t(), binary, CatalogV2.body()) :: IncidentIo.response()
+  @spec update(Client.t(), binary, request_body()) :: IncidentIo.response()
   def update(client \\ %Client{}, id, body) do
     put(
       "v2/catalog_entries/#{id}",


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace `CatalogV2.body()` in the `@spec update/3` typespec with the private `request_body()` type already defined in the same module — `CatalogV2` does not exist, causing a compiler warning

## Test plan

- [x] `mix compile --warnings-as-errors` produces no warnings for this module
- [x] `mix test test/catalog_entry_v2_test.exs` passes