### PR TITLE
fix(incidents_v1): prevent nil values being sent as query params

### DIFF
--- a/lib/incident_io/incidents_v1.ex
+++ b/lib/incident_io/incidents_v1.ex
@@ -70,11 +70,11 @@ defmodule IncidentIo.IncidentsV1 do
   More information at: https://api-docs.incident.io/tag/Incidents-V1#operation/Incidents%20V1_List
   """
   @spec list(Client.t(), request_options()) :: IncidentIo.response()
-  def list(client \\ %Client{}, opts \\ %{page_size: nil, after: nil, status: nil}) do
+  def list(client \\ %Client{}, opts \\ []) do
     get(
       "v1/incidents",
       client,
-      opts
+      Enum.reject(opts, fn {_, v} -> is_nil(v) end)
     )
   end
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Fix `list/2` default opts from `%{page_size: nil, after: nil, status: nil}` to `[]`, preventing every bare `list/1` call from sending `?page_size=&after=&status=` in the query string
- Filter out nil-valued opts before building the URL, consistent with `IncidentsV2` and `FollowUpsV2`

## Test plan

- [x] `mix test test/incidents_v1_test.exs` passes