### PR TITLE
fix(alert_events_v2): URL-encode token via add_params_to_url

### DIFF
--- a/lib/incident_io/alert_events_v2.ex
+++ b/lib/incident_io/alert_events_v2.ex
@@ -47,10 +47,12 @@ defmodule IncidentIo.AlertEventsV2 do
 
   More information at: https://api-docs.incident.io/tag/Alert-Events-V2#operation/Alert-Eventss%20V2_Create
   """
-  @spec create(Client.t(), binary, binary, AlertEventsV2.body()) :: IncidentIo.response()
+  @spec create(Client.t(), binary, binary, body()) :: IncidentIo.response()
   def create(client \\ %Client{}, alert_source_config_id, token, body) do
+    path = add_params_to_url("v2/alert_events/http/#{alert_source_config_id}", token: token)
+
     post(
-      "v2/alert_events/http/#{alert_source_config_id}?token=#{token}",
+      path,
       client,
       body
     )


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace manual string interpolation of the token query parameter with `add_params_to_url/2`, so special characters in the token are properly percent-encoded rather than producing a malformed URL
- Fix `@spec create/4` typespec: `AlertEventsV2.body()` → `body()` (the type is defined in the same module)

## Test plan

- [x] `mix test test/alert_events_v2_test.exs` passes