### PR TITLE
docs: add moduledoc to 14 resource modules hidden from docs

### DIFF
--- a/lib/incident_io/actions_v1.ex
+++ b/lib/incident_io/actions_v1.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.ActionsV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage actions attached to incidents.
+
+  Actions are tasks that responders create during an incident to track work
+  that needs to be done. This module covers the v1 Actions API.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/actions_v2.ex
+++ b/lib/incident_io/actions_v2.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.ActionsV2 do
-  @moduledoc false
+  @moduledoc """
+  Manage actions attached to incidents.
+
+  Actions are tasks that responders create during an incident to track work
+  that needs to be done. This module covers the v2 Actions API.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/alert_events_v2.ex
+++ b/lib/incident_io/alert_events_v2.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.AlertEventsV2 do
-  @moduledoc false
+  @moduledoc """
+  Send alert events to incident.io via HTTP alert sources.
+
+  Alert events allow external systems to push alerts into incident.io, which
+  can then trigger incidents automatically based on your alert routing rules.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/catalog_entry_v2.ex
+++ b/lib/incident_io/catalog_entry_v2.ex
@@ -1,5 +1,11 @@
 defmodule IncidentIo.CatalogEntryV2 do
-  @moduledoc false
+  @moduledoc """
+  Manage entries within catalog types.
+
+  Catalog entries are the individual items that belong to a catalog type.
+  Each entry can have attribute values, aliases, and an external ID for
+  syncing with external systems.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/catalog_resources_v2.ex
+++ b/lib/incident_io/catalog_resources_v2.ex
@@ -1,5 +1,11 @@
 defmodule IncidentIo.CatalogResourcesV2 do
-  @moduledoc false
+  @moduledoc """
+  List available catalog resources.
+
+  Catalog resources are the external resource types (e.g. PagerDuty services,
+  GitHub repositories) that can be referenced as attribute values in catalog
+  entries.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/catalog_types_schema_v2.ex
+++ b/lib/incident_io/catalog_types_schema_v2.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.CatalogTypesSchemaV2 do
-  @moduledoc false
+  @moduledoc """
+  Manage the schema for catalog types.
+
+  The schema defines the attributes that entries of a catalog type can have,
+  including their types, whether they are required, and how they are displayed.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/catalog_types_v2.ex
+++ b/lib/incident_io/catalog_types_v2.ex
@@ -1,5 +1,11 @@
 defmodule IncidentIo.CatalogTypesV2 do
-  @moduledoc false
+  @moduledoc """
+  Manage catalog types.
+
+  Catalog types represent categories of things in your organisation (e.g.
+  services, teams, customers). Each type has a schema defining the attributes
+  its entries can hold.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/custom_field_options_v1.ex
+++ b/lib/incident_io/custom_field_options_v1.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.CustomFieldOptionsV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage options for single- and multi-select custom fields.
+
+  When a custom field is of type `single_select` or `multi_select`, its
+  allowed values are defined as custom field options.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/custom_fields_v1.ex
+++ b/lib/incident_io/custom_fields_v1.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.CustomFieldsV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage custom fields for incidents.
+
+  Custom fields allow you to capture structured information on incidents beyond
+  the built-in fields. This module covers the v1 Custom Fields API.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/custom_fields_v2.ex
+++ b/lib/incident_io/custom_fields_v2.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.CustomFieldsV2 do
-  @moduledoc false
+  @moduledoc """
+  Manage custom fields for incidents.
+
+  Custom fields allow you to capture structured information on incidents beyond
+  the built-in fields. This module covers the v2 Custom Fields API.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/follow_ups_v2.ex
+++ b/lib/incident_io/follow_ups_v2.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.FollowUpsV2 do
-  @moduledoc false
+  @moduledoc """
+  List and inspect follow-up actions from incidents.
+
+  Follow-ups are actions identified during an incident that should be completed
+  after the incident is resolved. They can be filtered by incident and mode.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/incident_attachments_v1.ex
+++ b/lib/incident_io/incident_attachments_v1.ex
@@ -1,5 +1,11 @@
 defmodule IncidentIo.IncidentAttachmentsV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage attachments on incidents.
+
+  Incident attachments link external resources (e.g. Jira issues, GitHub PRs,
+  PagerDuty alerts) to an incident. Each attachment has a resource type and a
+  permalink to the external resource.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/incident_memberships_v1.ex
+++ b/lib/incident_io/incident_memberships_v1.ex
@@ -1,5 +1,10 @@
 defmodule IncidentIo.IncidentMembershipsV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage memberships on incidents.
+
+  Incident memberships control which users are members of a given incident.
+  Members receive notifications and appear on the incident timeline.
+  """
 
   import IncidentIo
   alias IncidentIo.Client

--- a/lib/incident_io/incident_roles_v1.ex
+++ b/lib/incident_io/incident_roles_v1.ex
@@ -1,5 +1,11 @@
 defmodule IncidentIo.IncidentRolesV1 do
-  @moduledoc false
+  @moduledoc """
+  Manage incident roles.
+
+  During an incident, you can assign responders to one of the incident roles
+  that are configured in your organisation settings. This module covers the
+  v1 Incident Roles API.
+  """
 
   import IncidentIo
   alias IncidentIo.Client


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace `@moduledoc false` with descriptive module docs on all 14 resource modules that were previously invisible in HexDocs
- Affected modules: `ActionsV1`, `ActionsV2`, `AlertEventsV2`, `CatalogEntryV2`, `CatalogResourcesV2`, `CatalogTypesSchemaV2`, `CatalogTypesV2`, `CustomFieldOptionsV1`, `CustomFieldsV1`, `CustomFieldsV2`, `FollowUpsV2`, `IncidentAttachmentsV1`, `IncidentMembershipsV1`, `IncidentRolesV1`

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` passes
- [x] `mix docs` renders all 14 modules in the sidebar