### PR TITLE
test: add error-response tests for all resource modules

### DIFF
--- a/test/actions_v1_test.exs
+++ b/test/actions_v1_test.exs
@@ -158,4 +158,37 @@ defmodule IncidentIo.ActionsV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0", true)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0", true)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/actions_v2_test.exs
+++ b/test/actions_v2_test.exs
@@ -130,4 +130,37 @@ defmodule IncidentIo.ActionsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/alert_events_v2_test.exs
+++ b/test/alert_events_v2_test.exs
@@ -53,4 +53,37 @@ defmodule IncidentIo.AlertEventsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = create(@client, "some-alert-source-config-id", "some-token", %{})
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = create(@client, "some-alert-source-config-id", "some-token", %{})
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/catalog_entry_v2_test.exs
+++ b/test/catalog_entry_v2_test.exs
@@ -1025,4 +1025,37 @@ defmodule IncidentIo.CatalogEntryV2Test do
              } == catalog_type
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/catalog_resources_v2_test.exs
+++ b/test/catalog_resources_v2_test.exs
@@ -51,4 +51,37 @@ defmodule IncidentIo.CatalogResourcesV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/catalog_types_schema_v2_test.exs
+++ b/test/catalog_types_schema_v2_test.exs
@@ -119,4 +119,37 @@ defmodule IncidentIo.CatalogTypesSchemaV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{attributes: []})
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{attributes: []})
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/catalog_types_v2_test.exs
+++ b/test/catalog_types_v2_test.exs
@@ -530,4 +530,37 @@ defmodule IncidentIo.CatalogTypesV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/custom_field_options_v1_test.exs
+++ b/test/custom_field_options_v1_test.exs
@@ -197,4 +197,37 @@ defmodule IncidentIo.CustomFieldOptionsV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/custom_fields_v1_test.exs
+++ b/test/custom_fields_v1_test.exs
@@ -343,4 +343,37 @@ defmodule IncidentIo.CustomFieldsV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/custom_fields_v2_test.exs
+++ b/test/custom_fields_v2_test.exs
@@ -218,4 +218,37 @@ defmodule IncidentIo.CustomFieldsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/follow_ups_v2_test.exs
+++ b/test/follow_ups_v2_test.exs
@@ -353,4 +353,37 @@ defmodule IncidentIo.FollowUpsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/identity_v1_test.exs
+++ b/test/identity_v1_test.exs
@@ -45,4 +45,37 @@ defmodule IncidentIo.IdentityV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = show(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = show(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_attachments_v1_test.exs
+++ b/test/incident_attachments_v1_test.exs
@@ -221,4 +221,52 @@ defmodule IncidentIo.IncidentAttachmentsV1Test do
       assert nil == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} =
+               create(@client, %{
+                 incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 resource: %{
+                   external_id: "ext-01FCNDV6P870EA6S7TK1DSYDG0",
+                   resource_type: "pager_duty_incident"
+                 }
+               })
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} =
+        create(@client, %{
+          incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          resource: %{
+            external_id: "ext-01FCNDV6P870EA6S7TK1DSYDG0",
+            resource_type: "pager_duty_incident"
+          }
+        })
+
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_memberships_v1_test.exs
+++ b/test/incident_memberships_v1_test.exs
@@ -65,4 +65,46 @@ defmodule IncidentIo.IncidentMembershipsV1Test do
       assert nil == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} =
+               create(@client, %{
+                 incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 user_id: "01FCNDV6P870EA6S7TK1DSYDG0"
+               })
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} =
+        create(@client, %{
+          incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          user_id: "01FCNDV6P870EA6S7TK1DSYDG0"
+        })
+
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_roles_v1_test.exs
+++ b/test/incident_roles_v1_test.exs
@@ -245,4 +245,37 @@ defmodule IncidentIo.IncidentRolesV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_roles_v2_test.exs
+++ b/test/incident_roles_v2_test.exs
@@ -235,4 +235,37 @@ defmodule IncidentIo.IncidentRolesV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_statuses_v1_test.exs
+++ b/test/incident_statuses_v1_test.exs
@@ -228,4 +228,37 @@ defmodule IncidentIo.IncidentStatusesV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_timestamps_v2_test.exs
+++ b/test/incident_timestamps_v2_test.exs
@@ -81,4 +81,37 @@ defmodule IncidentIo.IncidentTimestampsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incident_types_v1_test.exs
+++ b/test/incident_types_v1_test.exs
@@ -101,4 +101,37 @@ defmodule IncidentIo.IncidentTypesV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incidents_v1_test.exs
+++ b/test/incidents_v1_test.exs
@@ -857,4 +857,37 @@ defmodule IncidentIo.IncidentsV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/incidents_v2_test.exs
+++ b/test/incidents_v2_test.exs
@@ -1448,4 +1448,37 @@ defmodule IncidentIo.IncidentsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/open_api_v1_test.exs
+++ b/test/open_api_v1_test.exs
@@ -232,4 +232,37 @@ defmodule IncidentIo.OpenApiV1Test do
       assert "2.0" == swagger
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = show(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = show(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/schedule_entries_v2_test.exs
+++ b/test/schedule_entries_v2_test.exs
@@ -157,4 +157,37 @@ defmodule IncidentIo.ScheduleEntriesV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/schedules_v2_test.exs
+++ b/test/schedules_v2_test.exs
@@ -767,4 +767,37 @@ defmodule IncidentIo.SchedulesV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/severities_v1_test.exs
+++ b/test/severities_v1_test.exs
@@ -209,4 +209,37 @@ defmodule IncidentIo.SeveritiesV1Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/users_v2_test.exs
+++ b/test/users_v2_test.exs
@@ -205,4 +205,37 @@ defmodule IncidentIo.UsersV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end

--- a/test/workflows_v2_test.exs
+++ b/test/workflows_v2_test.exs
@@ -2285,4 +2285,37 @@ defmodule IncidentIo.WorkflowsV2Test do
              } == response
     end
   end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add a `describe "error responses"` block to all 27 resource test files, covering a 401 authentication failure response
- Each block asserts that (1) the HTTP status code is passed through correctly and (2) the error body is decoded and returned as a map
- Previously only happy-path 200 responses were tested across the entire test suite

## Test plan

- [x] `mix test` passes with 286 tests (54 new)