### PR TITLE
chore: update minimum Elixir version from 1.9 to 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule IncidentIo.Mixfile do
     [
       app: :incident_io,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.15",
       name: "IncidentIo",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Update `elixir: "~> 1.9"` to `"~> 1.15"` in `mix.exs` to match what the CI matrix actually tests (Elixir 1.15–1.19)
- The previous minimum was misleading — the library was never tested on Elixir 1.9–1.14, and Req 0.5 requires a newer runtime

## Test plan

- [x] `mix test` passes