### PR TITLE
feat: add IncidentIo.Pagination.stream/3 for cursor-based pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ defmodule MyIncidentIo do
 end
 ```
 
+## Pagination
+
+Many list endpoints return results in pages. The response includes a
+`pagination_meta.after` cursor that you pass as the `:after` option to fetch
+the next page.
+
+`IncidentIo.Pagination.stream/3` handles this for you. It wraps any 2-arity
+list function and returns a lazy `Stream` of page bodies, advancing through
+pages automatically until the cursor is `nil`:
+
+```elixir
+client = IncidentIo.Client.new(%{api_key: System.fetch_env!("INCIDENT_API_KEY")})
+
+# Collect every incident across all pages
+all_incidents =
+  IncidentIo.Pagination.stream(&IncidentIo.IncidentsV2.list/2, client)
+  |> Enum.flat_map(fn %{incidents: incidents} -> incidents end)
+
+# Process pages lazily without loading them all into memory
+IncidentIo.Pagination.stream(&IncidentIo.SchedulesV2.list/2, client)
+|> Stream.each(fn %{schedules: page} -> process(page) end)
+|> Stream.run()
+
+# Pass extra options (e.g. page_size) — :after is managed automatically
+IncidentIo.Pagination.stream(&IncidentIo.IncidentsV2.list/2, client, page_size: 50)
+|> Enum.flat_map(fn %{incidents: incidents} -> incidents end)
+```
+
+If a page returns a non-200 status code the stream stops and that page is not
+emitted. Call the underlying function directly if you need to inspect the error
+body.
+
 ## Development
 
 ### Requirements

--- a/lib/incident_io/pagination.ex
+++ b/lib/incident_io/pagination.ex
@@ -1,0 +1,72 @@
+defmodule IncidentIo.Pagination do
+  @moduledoc """
+  Helpers for iterating paginated incident.io API responses.
+
+  The incident.io API uses cursor-based pagination. List endpoints that support
+  pagination return a `pagination_meta` map with an `after` cursor. Pass that
+  cursor as the `:after` option on the next call to advance to the next page.
+
+  ## Example
+
+      # Collect all incidents across all pages
+      pages =
+        IncidentIo.Pagination.stream(&IncidentIo.IncidentsV2.list/2, client)
+        |> Enum.to_list()
+
+      # Stream all schedules, processing each page lazily
+      IncidentIo.Pagination.stream(&IncidentIo.SchedulesV2.list/2, client)
+      |> Stream.each(fn %{schedules: page} -> process(page) end)
+      |> Stream.run()
+
+  ## Non-200 responses
+
+  If a page request returns a non-200 status code, `stream/3` stops the stream
+  and the page with the error status is **not** emitted. Call the underlying
+  function directly if you need to inspect the error body.
+  """
+
+  @doc """
+  Returns a lazy stream of pages from a paginated list function.
+
+  `fun` must be a 2-arity function that accepts `(client, opts)` and returns
+  an `IncidentIo.response()`. Each page body is emitted as an element of the
+  stream.
+
+  ## Options
+
+  Any options accepted by `fun` can be passed in `opts`. The `:after` key is
+  managed automatically and should not be set manually.
+
+  ## Example
+
+      IncidentIo.Pagination.stream(&IncidentIo.IncidentsV2.list/2, client)
+      |> Enum.flat_map(fn %{incidents: incidents} -> incidents end)
+  """
+  @spec stream(
+          fun :: (IncidentIo.Client.t(), keyword -> IncidentIo.response()),
+          client :: IncidentIo.Client.t(),
+          opts :: keyword
+        ) :: Enumerable.t()
+  def stream(fun, client, opts \\ []) do
+    Stream.unfold(opts, fn
+      :done ->
+        nil
+
+      acc ->
+        case fun.(client, acc) do
+          {200, %{pagination_meta: %{after: nil}} = body, _} ->
+            {body, :done}
+
+          {200, %{pagination_meta: %{after: cursor}} = body, _} ->
+            {body, Keyword.put(acc, :after, cursor)}
+
+          {200, body, _} ->
+            # Response has no pagination_meta — treat as the only page
+            {body, :done}
+
+          _error ->
+            nil
+        end
+    end)
+  end
+end

--- a/test/pagination_test.exs
+++ b/test/pagination_test.exs
@@ -1,0 +1,82 @@
+defmodule IncidentIo.PaginationTest do
+  use IncidentIo.TestCase, async: true
+
+  doctest IncidentIo.Pagination
+
+  alias IncidentIo.Pagination
+
+  @client IncidentIo.Client.new()
+
+  defp page(items, after_cursor) do
+    %{
+      items: items,
+      pagination_meta: %{after: after_cursor, page_size: 25, total_record_count: 3}
+    }
+  end
+
+  describe "stream/3" do
+    test "emits all pages and stops when after cursor is nil" do
+      pages = [
+        {200, page(["a", "b"], "cursor1"), nil},
+        {200, page(["c"], nil), nil}
+      ]
+
+      call_count = :counters.new(1, [])
+      results_ref = :ets.new(:pages, [:set, :public])
+      :ets.insert(results_ref, {:pages, pages})
+
+      fun = fn _client, opts ->
+        :counters.add(call_count, 1, 1)
+        [{:pages, remaining}] = :ets.lookup(results_ref, :pages)
+        [_current | rest] = remaining
+        :ets.insert(results_ref, {:pages, rest})
+
+        after_val = Keyword.get(opts, :after)
+
+        case after_val do
+          nil -> Enum.at(pages, 0)
+          "cursor1" -> Enum.at(pages, 1)
+        end
+      end
+
+      result = Pagination.stream(fun, @client) |> Enum.to_list()
+
+      assert length(result) == 2
+      assert [%{items: ["a", "b"]}, %{items: ["c"]}] = result
+    end
+
+    test "emits a single page when response has no pagination_meta" do
+      fun = fn _client, _opts ->
+        {200, %{items: ["x", "y"]}, nil}
+      end
+
+      result = Pagination.stream(fun, @client) |> Enum.to_list()
+
+      assert [%{items: ["x", "y"]}] = result
+    end
+
+    test "stops stream on non-200 response" do
+      fun = fn _client, _opts ->
+        {401, %{type: "authentication_error"}, nil}
+      end
+
+      result = Pagination.stream(fun, @client) |> Enum.to_list()
+
+      assert result == []
+    end
+
+    test "passes initial opts to the function" do
+      received_opts = :ets.new(:opts, [:set, :public])
+
+      fun = fn _client, opts ->
+        :ets.insert(received_opts, {:opts, opts})
+        {200, %{items: []}, nil}
+      end
+
+      Pagination.stream(fun, @client, page_size: 10) |> Enum.to_list()
+
+      [{:opts, opts}] = :ets.lookup(received_opts, :opts)
+      assert Keyword.get(opts, :page_size) == 10
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.Pagination` module with a `stream/3` function that wraps any 2-arity list function and returns a lazy `Stream` of page bodies
- The stream advances automatically using the `pagination_meta.after` cursor returned by each page, stopping when the cursor is `nil` (last page) or when a non-200 response is received
- Fills the gap acknowledged by the existing `pagination_response` type definition — callers previously had to thread the cursor manually

## Usage

```elixir
# Collect all incidents across all pages
all_incidents =
  IncidentIo.Pagination.stream(&IncidentIo.IncidentsV2.list/2, client)
  |> Enum.flat_map(fn %{incidents: incidents} -> incidents end)
```

## Test plan

- [x] `mix test test/pagination_test.exs` passes (4 tests)
- [x] `mix test` passes