### PR TITLE
feat: complete CRUD operations for actions, follow-ups, and incident types

### DIFF
--- a/lib/incident_io.ex
+++ b/lib/incident_io.ex
@@ -70,6 +70,11 @@ defmodule IncidentIo do
     _request(:post, url(client, path), client.auth, body)
   end
 
+  @spec patch(binary, Client.t(), any) :: response
+  def patch(path, client, body \\ "") do
+    _request(:patch, url(client, path), client.auth, body)
+  end
+
   @spec put(binary, Client.t(), any) :: response
   def put(path, client, body \\ "") do
     _request(:put, url(client, path), client.auth, body)

--- a/lib/incident_io/actions_v2.ex
+++ b/lib/incident_io/actions_v2.ex
@@ -3,7 +3,8 @@ defmodule IncidentIo.ActionsV2 do
   Manage actions attached to incidents.
 
   Actions are tasks that responders create during an incident to track work
-  that needs to be done. This module covers the v2 Actions API.
+  that needs to be done. This module covers the v2 Actions API, supporting
+  full CRUD operations.
   """
 
   import IncidentIo
@@ -43,5 +44,38 @@ defmodule IncidentIo.ActionsV2 do
   @spec show(Client.t(), binary) :: IncidentIo.response()
   def show(client \\ %Client{}, action_id) do
     get("v2/actions/#{action_id}", client)
+  end
+
+  @doc """
+  Create an action for an incident.
+
+  ## Example
+
+      IncidentIo.ActionsV2.create(client, %{
+        assignee_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+        description: "Call the fire brigade",
+        incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+        status: "outstanding"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Actions-V2#operation/Actions%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/actions", client, body)
+  end
+
+  @doc """
+  Update an existing action.
+
+  ## Example
+
+      IncidentIo.ActionsV2.update(client, "some-action-id", %{status: "completed"})
+
+  More information at: https://api-docs.incident.io/tag/Actions-V2#operation/Actions%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, action_id, body) do
+    patch("v2/actions/#{action_id}", client, body)
   end
 end

--- a/lib/incident_io/follow_ups_v2.ex
+++ b/lib/incident_io/follow_ups_v2.ex
@@ -1,6 +1,6 @@
 defmodule IncidentIo.FollowUpsV2 do
   @moduledoc """
-  List and inspect follow-up actions from incidents.
+  Manage follow-up actions from incidents.
 
   Follow-ups are actions identified during an incident that should be completed
   after the incident is resolved. They can be filtered by incident and mode.
@@ -55,5 +55,38 @@ defmodule IncidentIo.FollowUpsV2 do
       "v2/follow_ups/#{id}",
       client
     )
+  end
+
+  @doc """
+  Create a follow-up for an incident.
+
+  ## Example
+
+      IncidentIo.FollowUpsV2.create(client, %{
+        description: "Call the fire brigade",
+        incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+        status: "outstanding",
+        title: "Cat is stuck in the tree"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Follow-ups-V2#operation/Follow-ups%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/follow_ups", client, body)
+  end
+
+  @doc """
+  Update an existing follow-up.
+
+  ## Example
+
+      IncidentIo.FollowUpsV2.update(client, "some-follow-up-id", %{status: "completed"})
+
+  More information at: https://api-docs.incident.io/tag/Follow-ups-V2#operation/Follow-ups%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v2/follow_ups/#{id}", client, body)
   end
 end

--- a/lib/incident_io/incident_types_v1.ex
+++ b/lib/incident_io/incident_types_v1.ex
@@ -1,6 +1,6 @@
 defmodule IncidentIo.IncidentTypesV1 do
   @moduledoc """
-  View incident types.
+  Manage incident types.
 
   With incident types enabled, you can tailor your process to the situation
   you're responding to with different custom fields and roles for each incident
@@ -42,5 +42,52 @@ defmodule IncidentIo.IncidentTypesV1 do
       "v1/incident_types/#{id}",
       client
     )
+  end
+
+  @doc """
+  Create a new incident type.
+
+  ## Example
+
+      IncidentIo.IncidentTypesV1.create(client, %{
+        description: "Customer facing production outages",
+        name: "Production Outage"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Incident-Types-V1#operation/Incident%20Types%20V1_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v1/incident_types", client, body)
+  end
+
+  @doc """
+  Update an existing incident type.
+
+  ## Example
+
+      IncidentIo.IncidentTypesV1.update(client, "some-incident-type-id", %{
+        name: "Updated Production Outage"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Incident-Types-V1#operation/Incident%20Types%20V1_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v1/incident_types/#{id}", client, body)
+  end
+
+  @doc """
+  Archives a single incident type.
+
+  ## Example
+
+      IncidentIo.IncidentTypesV1.destroy(client, "some-incident-type-id")
+
+  More information at: https://api-docs.incident.io/tag/Incident-Types-V1#operation/Incident%20Types%20V1_Delete
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete("v1/incident_types/#{id}", client)
   end
 end

--- a/test/actions_v2_test.exs
+++ b/test/actions_v2_test.exs
@@ -131,6 +131,113 @@ defmodule IncidentIo.ActionsV2Test do
     end
   end
 
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{
+            action: %{
+              assignee: %{
+                email: "lisa@incident.io",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "Lisa Karlin Curtis",
+                role: "viewer",
+                slack_user_id: "U02AYNF2XJM"
+              },
+              completed_at: "2021-08-17T13:28:57.801578Z",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Call the fire brigade",
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              status: "outstanding",
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 assignee_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 description: "Call the fire brigade",
+                 incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "outstanding"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          assignee_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          description: "Call the fire brigade",
+          incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          status: "outstanding"
+        })
+
+      assert %{
+               action: %{
+                 description: "Call the fire brigade",
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "outstanding"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            action: %{
+              assignee: %{
+                email: "lisa@incident.io",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "Lisa Karlin Curtis",
+                role: "viewer",
+                slack_user_id: "U02AYNF2XJM"
+              },
+              completed_at: "2021-08-17T13:28:57.801578Z",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Call the fire brigade",
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              status: "completed",
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{status: "completed"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{status: "completed"})
+
+      assert %{
+               action: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "completed"
+               }
+             } = response
+    end
+  end
+
   describe "error responses" do
     setup do
       Req.Test.stub(:incident_io, fn conn ->

--- a/test/follow_ups_v2_test.exs
+++ b/test/follow_ups_v2_test.exs
@@ -354,6 +354,139 @@ defmodule IncidentIo.FollowUpsV2Test do
     end
   end
 
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{
+            follow_up: %{
+              assignee: %{
+                email: "lisa@incident.io",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "Lisa Karlin Curtis",
+                role: "viewer",
+                slack_user_id: "U02AYNF2XJM"
+              },
+              completed_at: "2021-08-17T13:28:57.801578Z",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Call the fire brigade",
+              external_issue_reference: %{
+                issue_name: "INC-123",
+                issue_permalink:
+                  "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                provider: "asana"
+              },
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              priority: %{
+                description: "A follow-up that requires immediate attention.",
+                id: "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                name: "Urgent",
+                rank: 10
+              },
+              status: "outstanding",
+              title: "Cat is stuck in the tree",
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 description: "Call the fire brigade",
+                 incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "outstanding",
+                 title: "Cat is stuck in the tree"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          description: "Call the fire brigade",
+          incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          status: "outstanding",
+          title: "Cat is stuck in the tree"
+        })
+
+      assert %{
+               follow_up: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "outstanding",
+                 title: "Cat is stuck in the tree"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            follow_up: %{
+              assignee: %{
+                email: "lisa@incident.io",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "Lisa Karlin Curtis",
+                role: "viewer",
+                slack_user_id: "U02AYNF2XJM"
+              },
+              completed_at: "2021-08-17T13:28:57.801578Z",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Call the fire brigade",
+              external_issue_reference: %{
+                issue_name: "INC-123",
+                issue_permalink:
+                  "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                provider: "asana"
+              },
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              priority: %{
+                description: "A follow-up that requires immediate attention.",
+                id: "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                name: "Urgent",
+                rank: 10
+              },
+              status: "completed",
+              title: "Cat is stuck in the tree",
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{status: "completed"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{status: "completed"})
+
+      assert %{
+               follow_up: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "completed"
+               }
+             } = response
+    end
+  end
+
   describe "error responses" do
     setup do
       Req.Test.stub(:incident_io, fn conn ->

--- a/test/incident_types_v1_test.exs
+++ b/test/incident_types_v1_test.exs
@@ -102,6 +102,115 @@ defmodule IncidentIo.IncidentTypesV1Test do
     end
   end
 
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{
+            incident_type: %{
+              create_in_triage: "always",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Customer facing production outages",
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              is_default: false,
+              name: "Production Outage",
+              private_incidents_only: false,
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 description: "Customer facing production outages",
+                 name: "Production Outage"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          description: "Customer facing production outages",
+          name: "Production Outage"
+        })
+
+      assert %{
+               incident_type: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Production Outage"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            incident_type: %{
+              create_in_triage: "always",
+              created_at: "2021-08-17T13:28:57.801578Z",
+              description: "Customer facing production outages",
+              id: "01FCNDV6P870EA6S7TK1DSYDG0",
+              is_default: false,
+              name: "Updated Production Outage",
+              private_incidents_only: false,
+              updated_at: "2021-08-17T13:28:57.801578Z"
+            }
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated Production Outage"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated Production Outage"})
+
+      assert %{
+               incident_type: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Updated Production Outage"
+               }
+             } = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
   describe "error responses" do
     setup do
       Req.Test.stub(:incident_io, fn conn ->


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `patch/3` HTTP helper to `IncidentIo` to support PATCH requests
- Add `create/2` and `update/3` to `IncidentIo.ActionsV2` (update uses PATCH)
- Add `create/2` and `update/3` to `IncidentIo.FollowUpsV2`
- Add `create/2`, `update/3`, and `destroy/2` to `IncidentIo.IncidentTypesV1`
- Add corresponding tests for all new operations

These modules previously only implemented read operations (`list` and `show`) despite the API supporting full CRUD. This brings the library into alignment with the current API spec.