### PR TITLE
feat: add AlertsV2 module for alert management

### DIFF
--- a/lib/incident_io/alerts_v2.ex
+++ b/lib/incident_io/alerts_v2.ex
@@ -1,0 +1,64 @@
+defmodule IncidentIo.AlertsV2 do
+  @moduledoc """
+  Manage alerts within incident.io.
+
+  Alerts are notifications from monitoring systems that can trigger incidents.
+  This is distinct from `IncidentIo.AlertEventsV2` which handles inbound
+  webhook alert events from HTTP sources.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all alerts for an organisation.
+
+  Accepts optional pagination parameters:
+  - `:after` - Cursor for pagination
+  - `:page_size` - Number of items per page (default: 25, max: 250)
+
+  ## Example
+
+      IncidentIo.AlertsV2.list(client)
+
+      IncidentIo.AlertsV2.list(client, page_size: 50)
+
+  More information at: https://api-docs.incident.io/tag/Alerts-V2#operation/Alerts%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v2/alerts", client, opts)
+  end
+
+  @doc """
+  Create a new alert.
+
+  ## Example
+
+      IncidentIo.AlertsV2.create(client, %{
+        title: "High error rate on api.example.com",
+        status: "firing"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Alerts-V2#operation/Alerts%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/alerts", client, body)
+  end
+
+  @doc """
+  Get a single alert.
+
+  ## Example
+
+      IncidentIo.AlertsV2.show(client, "some-alert-id")
+
+  More information at: https://api-docs.incident.io/tag/Alerts-V2#operation/Alerts%20V2_Show
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get("v2/alerts/#{id}", client)
+  end
+end

--- a/test/alerts_v2_test.exs
+++ b/test/alerts_v2_test.exs
@@ -1,0 +1,182 @@
+defmodule IncidentIo.AlertsV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.AlertsV2
+
+  doctest IncidentIo.AlertsV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @alert_fixture %{
+    created_at: "2021-08-17T13:28:57.801578Z",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    status: "firing",
+    title: "High error rate on api.example.com"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            alerts: [@alert_fixture],
+            pagination_meta: %{after: nil, page_size: 25, total_record_count: 1}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of alerts" do
+      {200, %{alerts: alerts}, _} = list(@client)
+      assert Enum.count(alerts) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               alerts: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   status: "firing",
+                   title: "High error rate on api.example.com"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "list/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            alerts: [@alert_fixture],
+            pagination_meta: %{after: nil, page_size: 50, total_record_count: 1}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client, page_size: 50)
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client, page_size: 50)
+      assert %{alerts: [_]} = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{alert: @alert_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 title: "High error rate on api.example.com",
+                 status: "firing"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          title: "High error rate on api.example.com",
+          status: "firing"
+        })
+
+      assert %{
+               alert: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "firing",
+                 title: "High error rate on api.example.com"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{alert: @alert_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               alert: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 status: "firing",
+                 title: "High error rate on api.example.com"
+               }
+             } = response
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.AlertsV2` module with `list/1-2`, `create/2`, and `show/2`
- Add comprehensive tests for all operations

Implements the Alerts v2 API (`/v2/alerts`). Note this is distinct from `IncidentIo.AlertEventsV2` which handles inbound webhook alert event ingestion.