### PR TITLE
feat: add AlertRoutesV2 module for alert route management

### DIFF
--- a/lib/incident_io/alert_routes_v2.ex
+++ b/lib/incident_io/alert_routes_v2.ex
@@ -1,0 +1,82 @@
+defmodule IncidentIo.AlertRoutesV2 do
+  @moduledoc """
+  Manage alert routes within incident.io.
+
+  Alert routes determine how incoming alerts are routed to create or update
+  incidents based on conditions and configuration.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all alert routes for an organisation.
+
+  ## Example
+
+      IncidentIo.AlertRoutesV2.list(client)
+
+  More information at: https://api-docs.incident.io/tag/Alert-Routes-V2#operation/Alert%20Routes%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v2/alert_routes", client, opts)
+  end
+
+  @doc """
+  Create a new alert route.
+
+  ## Example
+
+      IncidentIo.AlertRoutesV2.create(client, %{name: "Production alerts"})
+
+  More information at: https://api-docs.incident.io/tag/Alert-Routes-V2#operation/Alert%20Routes%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/alert_routes", client, body)
+  end
+
+  @doc """
+  Get a single alert route.
+
+  ## Example
+
+      IncidentIo.AlertRoutesV2.show(client, "some-alert-route-id")
+
+  More information at: https://api-docs.incident.io/tag/Alert-Routes-V2#operation/Alert%20Routes%20V2_Show
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get("v2/alert_routes/#{id}", client)
+  end
+
+  @doc """
+  Update an existing alert route.
+
+  ## Example
+
+      IncidentIo.AlertRoutesV2.update(client, "some-alert-route-id", %{name: "Updated route"})
+
+  More information at: https://api-docs.incident.io/tag/Alert-Routes-V2#operation/Alert%20Routes%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v2/alert_routes/#{id}", client, body)
+  end
+
+  @doc """
+  Delete an alert route.
+
+  ## Example
+
+      IncidentIo.AlertRoutesV2.destroy(client, "some-alert-route-id")
+
+  More information at: https://api-docs.incident.io/tag/Alert-Routes-V2#operation/Alert%20Routes%20V2_Delete
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete("v2/alert_routes/#{id}", client)
+  end
+end

--- a/test/alert_routes_v2_test.exs
+++ b/test/alert_routes_v2_test.exs
@@ -1,0 +1,189 @@
+defmodule IncidentIo.AlertRoutesV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.AlertRoutesV2
+
+  doctest IncidentIo.AlertRoutesV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @alert_route_fixture %{
+    created_at: "2021-08-17T13:28:57.801578Z",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    name: "Production alerts",
+    updated_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{alert_routes: [@alert_route_fixture]})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of alert routes" do
+      {200, %{alert_routes: alert_routes}, _} = list(@client)
+      assert Enum.count(alert_routes) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               alert_routes: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Production alerts"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{alert_route: @alert_route_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} = create(@client, %{name: "Production alerts"})
+    end
+
+    test "returns expected response" do
+      {201, response, _} = create(@client, %{name: "Production alerts"})
+
+      assert %{
+               alert_route: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Production alerts"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{alert_route: @alert_route_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               alert_route: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Production alerts"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            alert_route: %{@alert_route_fixture | name: "Updated route"}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated route"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated route"})
+
+      assert %{alert_route: %{name: "Updated route"}} = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.AlertRoutesV2` module with `list/1-2`, `create/2`, `show/2`, `update/3`, and `destroy/2`
- Add comprehensive tests for all operations

Implements the Alert Routes v2 API (`/v2/alert_routes`). Alert routes determine how incoming alerts are routed to create or update incidents.