### PR TITLE
feat: add AlertSourcesV2 module for listing alert sources

### DIFF
--- a/lib/incident_io/alert_sources_v2.ex
+++ b/lib/incident_io/alert_sources_v2.ex
@@ -1,0 +1,25 @@
+defmodule IncidentIo.AlertSourcesV2 do
+  @moduledoc """
+  List available alert sources for your organisation.
+
+  Alert sources are integrations that can send alerts to incident.io, such as
+  PagerDuty, Datadog, or custom HTTP sources.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all alert sources for an organisation.
+
+  ## Example
+
+      IncidentIo.AlertSourcesV2.list(client)
+
+  More information at: https://api-docs.incident.io/tag/Alert-Sources-V2#operation/Alert%20Sources%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  def list(client \\ %Client{}) do
+    get("v2/alert_sources", client)
+  end
+end

--- a/test/alert_sources_v2_test.exs
+++ b/test/alert_sources_v2_test.exs
@@ -1,0 +1,86 @@
+defmodule IncidentIo.AlertSourcesV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.AlertSourcesV2
+
+  doctest IncidentIo.AlertSourcesV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            alert_sources: [
+              %{
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "PagerDuty",
+                type: "pager_duty"
+              }
+            ]
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of alert sources" do
+      {200, %{alert_sources: alert_sources}, _} = list(@client)
+      assert Enum.count(alert_sources) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               alert_sources: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "PagerDuty",
+                   type: "pager_duty"
+                 }
+               ]
+             } == response
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.AlertSourcesV2` module with `list/1`
- Add tests for the list operation and error responses

Implements the Alert Sources v2 API (`/v2/alert_sources`). Alert sources are integrations that can send alerts to incident.io.