### PR TITLE
feat: add IncidentRelationshipsV1 module

### DIFF
--- a/lib/incident_io/incident_relationships_v1.ex
+++ b/lib/incident_io/incident_relationships_v1.ex
@@ -1,0 +1,26 @@
+defmodule IncidentIo.IncidentRelationshipsV1 do
+  @moduledoc """
+  List relationships between incidents.
+
+  Incident relationships track how incidents are linked or related to each
+  other, such as parent-child or linked relationships.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all incident relationships for an organisation.
+
+  ## Example
+
+      IncidentIo.IncidentRelationshipsV1.list(client)
+
+  More information at: https://api-docs.incident.io/tag/Incident-Relationships-V1#operation/Incident%20Relationships%20V1_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v1/incident_relationships", client, opts)
+  end
+end

--- a/test/incident_relationships_v1_test.exs
+++ b/test/incident_relationships_v1_test.exs
@@ -1,0 +1,89 @@
+defmodule IncidentIo.IncidentRelationshipsV1Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.IncidentRelationshipsV1
+
+  doctest IncidentIo.IncidentRelationshipsV1
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            incident_relationships: [
+              %{
+                created_at: "2021-08-17T13:28:57.801578Z",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                source_incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                target_incident_id: "01FCNDV6P870EA6S7TK1DSYDG1",
+                type: "linked"
+              }
+            ]
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of incident relationships" do
+      {200, %{incident_relationships: relationships}, _} = list(@client)
+      assert Enum.count(relationships) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               incident_relationships: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   source_incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   target_incident_id: "01FCNDV6P870EA6S7TK1DSYDG1",
+                   type: "linked"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.IncidentRelationshipsV1` module with `list/1-2`
- Add tests for the list operation and error responses

Implements the Incident Relationships v1 API (`/v1/incident_relationships`).