### PR TITLE
feat: add MaintenanceWindowsV2 module

### DIFF
--- a/lib/incident_io/maintenance_windows_v2.ex
+++ b/lib/incident_io/maintenance_windows_v2.ex
@@ -1,0 +1,94 @@
+defmodule IncidentIo.MaintenanceWindowsV2 do
+  @moduledoc """
+  Manage maintenance windows for your organisation.
+
+  Maintenance windows suppress alerts during scheduled downtime, preventing
+  unnecessary incident creation during planned maintenance periods.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all maintenance windows for an organisation.
+
+  Accepts optional pagination parameters:
+  - `:after` - Cursor for pagination
+  - `:page_size` - Number of items per page (default: 25, max: 250)
+
+  ## Example
+
+      IncidentIo.MaintenanceWindowsV2.list(client)
+
+      IncidentIo.MaintenanceWindowsV2.list(client, page_size: 50)
+
+  More information at: https://api-docs.incident.io/tag/Maintenance-Windows-V2#operation/Maintenance%20Windows%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v2/maintenance_windows", client, opts)
+  end
+
+  @doc """
+  Create a new maintenance window.
+
+  ## Example
+
+      IncidentIo.MaintenanceWindowsV2.create(client, %{
+        name: "Weekly maintenance",
+        starts_at: "2021-08-17T13:00:00.000000Z",
+        ends_at: "2021-08-17T14:00:00.000000Z"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Maintenance-Windows-V2#operation/Maintenance%20Windows%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/maintenance_windows", client, body)
+  end
+
+  @doc """
+  Get a single maintenance window.
+
+  ## Example
+
+      IncidentIo.MaintenanceWindowsV2.show(client, "some-maintenance-window-id")
+
+  More information at: https://api-docs.incident.io/tag/Maintenance-Windows-V2#operation/Maintenance%20Windows%20V2_Show
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get("v2/maintenance_windows/#{id}", client)
+  end
+
+  @doc """
+  Update an existing maintenance window.
+
+  ## Example
+
+      IncidentIo.MaintenanceWindowsV2.update(client, "some-maintenance-window-id", %{
+        name: "Updated maintenance window"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Maintenance-Windows-V2#operation/Maintenance%20Windows%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v2/maintenance_windows/#{id}", client, body)
+  end
+
+  @doc """
+  Delete a maintenance window.
+
+  ## Example
+
+      IncidentIo.MaintenanceWindowsV2.destroy(client, "some-maintenance-window-id")
+
+  More information at: https://api-docs.incident.io/tag/Maintenance-Windows-V2#operation/Maintenance%20Windows%20V2_Delete
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete("v2/maintenance_windows/#{id}", client)
+  end
+end

--- a/test/maintenance_windows_v2_test.exs
+++ b/test/maintenance_windows_v2_test.exs
@@ -1,0 +1,200 @@
+defmodule IncidentIo.MaintenanceWindowsV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.MaintenanceWindowsV2
+
+  doctest IncidentIo.MaintenanceWindowsV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @maintenance_window_fixture %{
+    created_at: "2021-08-17T13:28:57.801578Z",
+    ends_at: "2021-08-17T14:28:57.801578Z",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    name: "Weekly maintenance",
+    starts_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{maintenance_windows: [@maintenance_window_fixture]})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of maintenance windows" do
+      {200, %{maintenance_windows: maintenance_windows}, _} = list(@client)
+      assert Enum.count(maintenance_windows) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               maintenance_windows: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Weekly maintenance"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{maintenance_window: @maintenance_window_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 name: "Weekly maintenance",
+                 starts_at: "2021-08-17T13:00:00.000000Z",
+                 ends_at: "2021-08-17T14:00:00.000000Z"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          name: "Weekly maintenance",
+          starts_at: "2021-08-17T13:00:00.000000Z",
+          ends_at: "2021-08-17T14:00:00.000000Z"
+        })
+
+      assert %{
+               maintenance_window: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Weekly maintenance"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{maintenance_window: @maintenance_window_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               maintenance_window: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Weekly maintenance"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            maintenance_window: %{@maintenance_window_fixture | name: "Updated maintenance"}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated maintenance"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated maintenance"})
+
+      assert %{maintenance_window: %{name: "Updated maintenance"}} = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.MaintenanceWindowsV2` module with `list/1-2`, `create/2`, `show/2`, `update/3`, and `destroy/2`
- Add comprehensive tests for all operations

Implements the Maintenance Windows v2 API (`/v2/maintenance_windows`). Maintenance windows suppress alerts during scheduled downtime.