### PR TITLE
feat: add PostMortemsV2 module

### DIFF
--- a/lib/incident_io/post_mortems_v2.ex
+++ b/lib/incident_io/post_mortems_v2.ex
@@ -1,0 +1,79 @@
+defmodule IncidentIo.PostMortemsV2 do
+  @moduledoc """
+  Manage post-mortems for incidents.
+
+  Post-mortems document lessons learned and follow-up actions after an incident
+  is resolved. They help teams improve their processes and prevent recurrence.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all post-mortems for an organisation.
+
+  Accepts optional pagination parameters:
+  - `:after` - Cursor for pagination
+  - `:page_size` - Number of items per page (default: 25, max: 250)
+
+  ## Example
+
+      IncidentIo.PostMortemsV2.list(client)
+
+      IncidentIo.PostMortemsV2.list(client, page_size: 50)
+
+  More information at: https://api-docs.incident.io/tag/Post-Mortems-V2#operation/Post%20Mortems%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v2/post_mortems", client, opts)
+  end
+
+  @doc """
+  Create a new post-mortem.
+
+  ## Example
+
+      IncidentIo.PostMortemsV2.create(client, %{
+        incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+        name: "Incident post-mortem"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Post-Mortems-V2#operation/Post%20Mortems%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/post_mortems", client, body)
+  end
+
+  @doc """
+  Get a single post-mortem.
+
+  ## Example
+
+      IncidentIo.PostMortemsV2.show(client, "some-post-mortem-id")
+
+  More information at: https://api-docs.incident.io/tag/Post-Mortems-V2#operation/Post%20Mortems%20V2_Show
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get("v2/post_mortems/#{id}", client)
+  end
+
+  @doc """
+  Update an existing post-mortem.
+
+  ## Example
+
+      IncidentIo.PostMortemsV2.update(client, "some-post-mortem-id", %{
+        name: "Updated post-mortem"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Post-Mortems-V2#operation/Post%20Mortems%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v2/post_mortems/#{id}", client, body)
+  end
+end

--- a/test/post_mortems_v2_test.exs
+++ b/test/post_mortems_v2_test.exs
@@ -1,0 +1,179 @@
+defmodule IncidentIo.PostMortemsV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.PostMortemsV2
+
+  doctest IncidentIo.PostMortemsV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @post_mortem_fixture %{
+    created_at: "2021-08-17T13:28:57.801578Z",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    name: "Incident post-mortem",
+    updated_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{post_mortems: [@post_mortem_fixture]})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of post mortems" do
+      {200, %{post_mortems: post_mortems}, _} = list(@client)
+      assert Enum.count(post_mortems) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               post_mortems: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Incident post-mortem"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{post_mortem: @post_mortem_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Incident post-mortem"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          incident_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          name: "Incident post-mortem"
+        })
+
+      assert %{
+               post_mortem: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Incident post-mortem"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{post_mortem: @post_mortem_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               post_mortem: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Incident post-mortem"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            post_mortem: %{@post_mortem_fixture | name: "Updated post-mortem"}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated post-mortem"})
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated post-mortem"})
+
+      assert %{post_mortem: %{name: "Updated post-mortem"}} = response
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.PostMortemsV2` module with `list/1-2`, `create/2`, `show/2`, and `update/3`
- Add comprehensive tests for all operations

Implements the Post-Mortems v2 API (`/v2/post_mortems`). Note: the API has no DELETE endpoint for post-mortems.