### PR TITLE
feat: add AlertPrioritiesV2 module for listing alert priorities

### DIFF
--- a/lib/incident_io/alert_priorities_v2.ex
+++ b/lib/incident_io/alert_priorities_v2.ex
@@ -1,0 +1,25 @@
+defmodule IncidentIo.AlertPrioritiesV2 do
+  @moduledoc """
+  List alert priorities configured for your organisation.
+
+  Alert priorities determine the severity level of alerts and can influence
+  how they are routed and handled.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all alert priorities for an organisation.
+
+  ## Example
+
+      IncidentIo.AlertPrioritiesV2.list(client)
+
+  More information at: https://api-docs.incident.io/tag/Alert-Priorities-V2#operation/Alert%20Priorities%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  def list(client \\ %Client{}) do
+    get("v2/alert_priorities", client)
+  end
+end

--- a/test/alert_priorities_v2_test.exs
+++ b/test/alert_priorities_v2_test.exs
@@ -1,0 +1,88 @@
+defmodule IncidentIo.AlertPrioritiesV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.AlertPrioritiesV2
+
+  doctest IncidentIo.AlertPrioritiesV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            alert_priorities: [
+              %{
+                description: "A high-priority alert requiring immediate attention.",
+                id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                name: "High",
+                rank: 1
+              }
+            ]
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of alert priorities" do
+      {200, %{alert_priorities: alert_priorities}, _} = list(@client)
+      assert Enum.count(alert_priorities) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               alert_priorities: [
+                 %{
+                   description: "A high-priority alert requiring immediate attention.",
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "High",
+                   rank: 1
+                 }
+               ]
+             } == response
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.AlertPrioritiesV2` module with `list/1`
- Add tests for the list operation and error responses

Implements the Alert Priorities v2 API (`/v2/alert_priorities`).