### PR TITLE
feat: add EscalationPathsV2 module for escalation path management

### DIFF
--- a/lib/incident_io/escalation_paths_v2.ex
+++ b/lib/incident_io/escalation_paths_v2.ex
@@ -1,0 +1,90 @@
+defmodule IncidentIo.EscalationPathsV2 do
+  @moduledoc """
+  Manage escalation paths for your organisation.
+
+  Escalation paths define how alerts and incidents are escalated through your
+  team, specifying who gets notified and when if an incident goes unacknowledged.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @doc """
+  List all escalation paths for an organisation.
+
+  Accepts optional pagination parameters:
+  - `:after` - Cursor for pagination
+  - `:page_size` - Number of items per page (default: 25, max: 250)
+
+  ## Example
+
+      IncidentIo.EscalationPathsV2.list(client)
+
+      IncidentIo.EscalationPathsV2.list(client, page_size: 50)
+
+  More information at: https://api-docs.incident.io/tag/Escalation-Paths-V2#operation/Escalation%20Paths%20V2_List
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  @spec list(Client.t(), keyword) :: IncidentIo.response()
+  def list(client \\ %Client{}, opts \\ []) do
+    get("v2/escalation_paths", client, opts)
+  end
+
+  @doc """
+  Create a new escalation path.
+
+  ## Example
+
+      IncidentIo.EscalationPathsV2.create(client, %{name: "Default Escalation Path"})
+
+  More information at: https://api-docs.incident.io/tag/Escalation-Paths-V2#operation/Escalation%20Paths%20V2_Create
+  """
+  @spec create(Client.t(), map()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post("v2/escalation_paths", client, body)
+  end
+
+  @doc """
+  Get a single escalation path.
+
+  ## Example
+
+      IncidentIo.EscalationPathsV2.show(client, "some-escalation-path-id")
+
+  More information at: https://api-docs.incident.io/tag/Escalation-Paths-V2#operation/Escalation%20Paths%20V2_Show
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get("v2/escalation_paths/#{id}", client)
+  end
+
+  @doc """
+  Update an existing escalation path.
+
+  ## Example
+
+      IncidentIo.EscalationPathsV2.update(client, "some-escalation-path-id", %{
+        name: "Updated Escalation Path"
+      })
+
+  More information at: https://api-docs.incident.io/tag/Escalation-Paths-V2#operation/Escalation%20Paths%20V2_Update
+  """
+  @spec update(Client.t(), binary, map()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put("v2/escalation_paths/#{id}", client, body)
+  end
+
+  @doc """
+  Delete an escalation path.
+
+  ## Example
+
+      IncidentIo.EscalationPathsV2.destroy(client, "some-escalation-path-id")
+
+  More information at: https://api-docs.incident.io/tag/Escalation-Paths-V2#operation/Escalation%20Paths%20V2_Delete
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete("v2/escalation_paths/#{id}", client)
+  end
+end

--- a/test/escalation_paths_v2_test.exs
+++ b/test/escalation_paths_v2_test.exs
@@ -1,0 +1,191 @@
+defmodule IncidentIo.EscalationPathsV2Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.EscalationPathsV2
+
+  doctest IncidentIo.EscalationPathsV2
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @escalation_path_fixture %{
+    created_at: "2021-08-17T13:28:57.801578Z",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    name: "Default Escalation Path",
+    updated_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{escalation_paths: [@escalation_path_fixture]})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of escalation paths" do
+      {200, %{escalation_paths: escalation_paths}, _} = list(@client)
+      assert Enum.count(escalation_paths) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               escalation_paths: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Default Escalation Path"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{escalation_path: @escalation_path_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} = create(@client, %{name: "Default Escalation Path"})
+    end
+
+    test "returns expected response" do
+      {201, response, _} = create(@client, %{name: "Default Escalation Path"})
+
+      assert %{
+               escalation_path: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Default Escalation Path"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{escalation_path: @escalation_path_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               escalation_path: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Default Escalation Path"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            escalation_path: %{@escalation_path_fixture | name: "Updated Escalation Path"}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{
+                 name: "Updated Escalation Path"
+               })
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated Escalation Path"})
+
+      assert %{escalation_path: %{name: "Updated Escalation Path"}} = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.EscalationPathsV2` module with `list/1-2`, `create/2`, `show/2`, `update/3`, and `destroy/2`
- Add comprehensive tests for all operations

Implements the Escalation Paths v2 API (`/v2/escalation_paths`).