### PR TITLE
feat: add CatalogTypesV3 and CatalogEntriesV3 modules

### DIFF
--- a/lib/incident_io/catalog_entries_v3.ex
+++ b/lib/incident_io/catalog_entries_v3.ex
@@ -1,0 +1,174 @@
+defmodule IncidentIo.CatalogEntriesV3 do
+  @moduledoc """
+  Manage entries within catalog types.
+
+  Catalog entries are the individual items that belong to a catalog type.
+  Each entry can have attribute values, aliases, and an external ID for
+  syncing with external systems. This module covers the v3 Catalog API.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @typep request_body :: %{
+           optional(:catalog_type_id) => binary,
+           aliases: list,
+           attribute_values: %{
+             binary => %{
+               array_value: [engine_param_binding, ...],
+               value: engine_param_binding
+             }
+           },
+           external_id: binary,
+           name: binary,
+           rank: integer
+         }
+  @typep engine_param_binding :: %{
+           literal: binary,
+           reference: binary
+         }
+
+  @doc """
+  List entries for a catalog type.
+
+  ## Example
+
+      IncidentIo.CatalogEntriesV3.list(client, "some-catalog-type-id")
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_ListEntries
+  """
+  @spec list(Client.t(), binary) :: IncidentIo.response()
+  @spec list(Client.t(), binary, integer) :: IncidentIo.response()
+  def list(client \\ %Client{}, catalog_type_id, page_size \\ 25) do
+    get(
+      "v3/catalog_entries",
+      client,
+      %{
+        catalog_type_id: catalog_type_id,
+        page_size: page_size
+      }
+    )
+  end
+
+  @doc """
+  Create an entry within the catalog.
+
+  Catalog entry body example:
+  ```elixir
+  %{
+    aliases: [
+      "lawrence@incident.io",
+      "lawrence"
+    ],
+    attribute_values: %{
+      abc123: %{
+        array_value: [
+          %{
+            literal: "SEV123",
+            reference: "incident.severity"
+          }
+        ],
+        value: %{
+          literal: "SEV123",
+          reference: "incident.severity"
+        }
+      }
+    },
+    catalog_type_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    external_id: "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+    name: "Primary On-call",
+    rank: 3
+  }
+  ```
+
+  ## Example
+
+      IncidentIo.CatalogEntriesV3.create(client, body)
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_CreateEntry
+  """
+  @spec create(Client.t(), request_body()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post(
+      "v3/catalog_entries",
+      client,
+      body
+    )
+  end
+
+  @doc """
+  Show a single catalog entry.
+
+  ## Example
+
+      IncidentIo.CatalogEntriesV3.show(client, "some-catalog-entry-id")
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_ShowEntry
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get(
+      "v3/catalog_entries/#{id}",
+      client
+    )
+  end
+
+  @doc """
+  Updates an existing catalog entry.
+
+  Catalog entry body example:
+  ```elixir
+  %{
+    aliases: [
+      "not lawrence"
+    ],
+    attribute_values: %{
+      abc123: %{
+        array_value: [
+          %{
+            literal: "SEV123",
+            reference: "incident.severity"
+          }
+        ],
+        value: %{
+          literal: "SEV123",
+          reference: "incident.severity"
+        }
+      }
+    },
+    name: "Was Primary On-call",
+    rank: 5
+  }
+  ```
+  ## Example
+
+      IncidentIo.CatalogEntriesV3.update(client, "some-catalog-entry-id", body)
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_UpdateEntry
+  """
+  @spec update(Client.t(), binary, request_body()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put(
+      "v3/catalog_entries/#{id}",
+      client,
+      body
+    )
+  end
+
+  @doc """
+  Archives a catalog entry.
+
+  ## Example
+
+      IncidentIo.CatalogEntriesV3.destroy(client, "some-catalog-entry-id")
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_DestroyEntry
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete(
+      "v3/catalog_entries/#{id}",
+      client
+    )
+  end
+end

--- a/lib/incident_io/catalog_types_v3.ex
+++ b/lib/incident_io/catalog_types_v3.ex
@@ -1,0 +1,172 @@
+defmodule IncidentIo.CatalogTypesV3 do
+  @moduledoc """
+  Manage catalog types.
+
+  Catalog types represent categories of things in your organisation (e.g.
+  services, teams, customers). Each type has a schema defining the attributes
+  its entries can hold. This module covers the v3 Catalog API.
+  """
+
+  import IncidentIo
+  alias IncidentIo.Client
+
+  @typep color :: [
+           :yellow | :green | :blue | :violet | :pink | :cyan | :orange
+         ]
+  @typep icon :: [
+           :bolt
+           | :box
+           | :briefcase
+           | :browser
+           | :bulb
+           | :calendar
+           | :clock
+           | :cog
+           | :components
+           | :database
+           | :doc
+           | :email
+           | :files
+           | :flag
+           | :folder
+           | :globe
+           | :money
+           | :server
+           | :severity
+           | :store
+           | :star
+           | :tag
+           | :user
+           | :users
+         ]
+  @typep request_body :: %{
+           optional(:annotations) => %{
+             binary => binary
+           },
+           optional(:color) => color(),
+           optional(:icon) => icon(),
+           optional(:ranked) => binary,
+           optional(:source_repo_url) => binary,
+           optional(:type_name) => binary,
+           description: binary,
+           name: binary
+         }
+
+  @doc """
+  List entries for a catalog type.
+
+  ## Example
+
+      IncidentIo.CatalogTypesV3.list(client)
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_ListTypes
+  """
+  @spec list(Client.t()) :: IncidentIo.response()
+  def list(client \\ %Client{}) do
+    get(
+      "v3/catalog_types",
+      client
+    )
+  end
+
+  @doc """
+  Create a catalog type.
+
+  Catalog type body example:
+  ```elixir
+  %{
+      annotations: %{
+        "incident.io/catalog-importer/id": "id-of-config"
+      },
+      color: "yellow",
+      description: "Represents Kubernetes clusters that we run inside of GKE.",
+      icon: "bolt",
+      name: "Kubernetes Cluster",
+      ranked: true,
+      source_repo_url: "https://github.com/my-company/incident-io-catalog",
+      type_name: "Custom[\\"BackstageGroup\\"]"
+  }
+  ```
+
+  ## Example
+
+      IncidentIo.CatalogTypesV3.create(client, body)
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_CreateType
+  """
+  @spec create(Client.t(), request_body()) :: IncidentIo.response()
+  def create(client \\ %Client{}, body) do
+    post(
+      "v3/catalog_types",
+      client,
+      body
+    )
+  end
+
+  @doc """
+  Show a single catalog type.
+
+  ## Example
+
+      IncidentIo.CatalogTypesV3.show(client, "some-catalog-type-id")
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_ShowType
+  """
+  @spec show(Client.t(), binary) :: IncidentIo.response()
+  def show(client \\ %Client{}, id) do
+    get(
+      "v3/catalog_types/#{id}",
+      client
+    )
+  end
+
+  @doc """
+  Updates an existing catalog type.
+
+  Catalog type body example:
+  ```elixir
+  %{
+      annotations: %{
+        "incident.io/catalog-importer/id": "id-of-config"
+      },
+      color: "yellow",
+      description: "Represents Kubernetes clusters that we run inside of GKE.",
+      icon: "bolt",
+      name: "Kubernetes Cluster",
+      ranked: true,
+      source_repo_url: "https://github.com/my-company/incident-io-catalog"
+  }
+  ```
+
+  ## Example
+
+      IncidentIo.CatalogTypesV3.update(client, "some-catalog-type-id", body)
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_UpdateType
+  """
+  @spec update(Client.t(), binary, request_body()) :: IncidentIo.response()
+  def update(client \\ %Client{}, id, body) do
+    put(
+      "v3/catalog_types/#{id}",
+      client,
+      body
+    )
+  end
+
+  @doc """
+  Archives a catalog type and associated entries.
+
+  ## Example
+
+      IncidentIo.CatalogTypesV3.destroy(client, "some-catalog-type-id")
+
+  More information at: https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_DestroyType
+  """
+  @spec destroy(Client.t(), binary) :: IncidentIo.response()
+  def destroy(client \\ %Client{}, id) do
+    delete(
+      "v3/catalog_types/#{id}",
+      client
+    )
+  end
+end

--- a/test/catalog_entries_v3_test.exs
+++ b/test/catalog_entries_v3_test.exs
@@ -1,0 +1,221 @@
+defmodule IncidentIo.CatalogEntriesV3Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.CatalogEntriesV3
+
+  doctest IncidentIo.CatalogEntriesV3
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @catalog_entry_fixture %{
+    aliases: ["lawrence@incident.io", "lawrence"],
+    attribute_values: %{
+      abc123: %{
+        array_value: [%{literal: "SEV123", reference: "incident.severity"}],
+        value: %{literal: "SEV123", reference: "incident.severity"}
+      }
+    },
+    catalog_type_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    created_at: "2021-08-17T13:28:57.801578Z",
+    external_id: "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    name: "Primary On-call",
+    rank: 3,
+    updated_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            catalog_entries: [@catalog_entry_fixture],
+            pagination_meta: %{after: nil, page_size: 25, total_record_count: 1}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected number of catalog entries" do
+      {200, %{catalog_entries: catalog_entries}, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert Enum.count(catalog_entries) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               catalog_entries: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Primary On-call"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{catalog_entry: @catalog_entry_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 aliases: ["lawrence@incident.io"],
+                 attribute_values: %{},
+                 catalog_type_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 external_id: "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                 name: "Primary On-call",
+                 rank: 3
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          aliases: ["lawrence@incident.io"],
+          attribute_values: %{},
+          catalog_type_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+          external_id: "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          name: "Primary On-call",
+          rank: 3
+        })
+
+      assert %{
+               catalog_entry: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Primary On-call"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{catalog_entry: @catalog_entry_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               catalog_entry: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Primary On-call"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            catalog_entry: %{@catalog_entry_fixture | name: "Was Primary On-call", rank: 5}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{
+                 name: "Was Primary On-call",
+                 rank: 5
+               })
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Was Primary On-call", rank: 5})
+
+      assert %{catalog_entry: %{name: "Was Primary On-call", rank: 5}} = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end

--- a/test/catalog_types_v3_test.exs
+++ b/test/catalog_types_v3_test.exs
@@ -1,0 +1,208 @@
+defmodule IncidentIo.CatalogTypesV3Test do
+  use IncidentIo.TestCase, async: true
+  import IncidentIo.CatalogTypesV3
+
+  doctest IncidentIo.CatalogTypesV3
+
+  @client IncidentIo.Client.new(%{api_key: "yourApiKeyGoesHere"})
+
+  @catalog_type_fixture %{
+    annotations: %{
+      "incident.io/catalog-importer/id": "id-of-config"
+    },
+    color: "yellow",
+    created_at: "2021-08-17T13:28:57.801578Z",
+    description: "Represents Kubernetes clusters that we run inside of GKE.",
+    estimated_count: 7,
+    icon: "bolt",
+    id: "01FCNDV6P870EA6S7TK1DSYDG0",
+    is_editable: false,
+    name: "Kubernetes Cluster",
+    ranked: true,
+    updated_at: "2021-08-17T13:28:57.801578Z"
+  }
+
+  describe "list/1" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{catalog_types: [@catalog_type_fixture]})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = list(@client)
+    end
+
+    test "returns expected number of catalog types" do
+      {200, %{catalog_types: catalog_types}, _} = list(@client)
+      assert Enum.count(catalog_types) == 1
+    end
+
+    test "returns expected response" do
+      {200, response, _} = list(@client)
+
+      assert %{
+               catalog_types: [
+                 %{
+                   id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                   name: "Kubernetes Cluster"
+                 }
+               ]
+             } = response
+    end
+  end
+
+  describe "create/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          201,
+          Jason.encode!(%{catalog_type: @catalog_type_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {201, _, _} =
+               create(@client, %{
+                 description: "Represents Kubernetes clusters that we run inside of GKE.",
+                 name: "Kubernetes Cluster"
+               })
+    end
+
+    test "returns expected response" do
+      {201, response, _} =
+        create(@client, %{
+          description: "Represents Kubernetes clusters that we run inside of GKE.",
+          name: "Kubernetes Cluster"
+        })
+
+      assert %{
+               catalog_type: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Kubernetes Cluster"
+               }
+             } = response
+    end
+  end
+
+  describe "show/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{catalog_type: @catalog_type_fixture})
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns expected response" do
+      {200, response, _} = show(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+
+      assert %{
+               catalog_type: %{
+                 id: "01FCNDV6P870EA6S7TK1DSYDG0",
+                 name: "Kubernetes Cluster"
+               }
+             } = response
+    end
+  end
+
+  describe "update/3" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            catalog_type: %{@catalog_type_fixture | name: "Updated Kubernetes Cluster"}
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {200, _, _} =
+               update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{
+                 name: "Updated Kubernetes Cluster"
+               })
+    end
+
+    test "returns expected response" do
+      {200, response, _} =
+        update(@client, "01FCNDV6P870EA6S7TK1DSYDG0", %{name: "Updated Kubernetes Cluster"})
+
+      assert %{catalog_type: %{name: "Updated Kubernetes Cluster"}} = response
+    end
+  end
+
+  describe "destroy/2" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(conn, 204, "")
+      end)
+
+      :ok
+    end
+
+    test "returns expected HTTP status code" do
+      assert {204, _, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+    end
+
+    test "returns nil body" do
+      {204, response, _} = destroy(@client, "01FCNDV6P870EA6S7TK1DSYDG0")
+      assert is_nil(response)
+    end
+  end
+
+  describe "error responses" do
+    setup do
+      Req.Test.stub(:incident_io, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          401,
+          Jason.encode!(%{
+            errors: [
+              %{
+                code: "missing_authorization_material",
+                message: "No authorization material provided in request"
+              }
+            ],
+            request_id: "01FCNDV6P870EA6S7TK1DSYDG0",
+            status: 401,
+            type: "authentication_error"
+          })
+        )
+      end)
+
+      :ok
+    end
+
+    test "returns 401 on authentication failure" do
+      assert {401, _, _} = list(@client)
+    end
+
+    test "returns error body on authentication failure" do
+      {401, response, _} = list(@client)
+      assert %{type: "authentication_error", status: 401} = response
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `IncidentIo.CatalogTypesV3` module with `list/1`, `create/2`, `show/2`, `update/3`, and `destroy/2`
- Add `IncidentIo.CatalogEntriesV3` module with `list/2-3`, `create/2`, `show/2`, `update/3`, and `destroy/2`
- Add comprehensive tests for all operations on both modules

Adds v3 counterparts to the existing `CatalogTypesV2` and `CatalogEntryV2` modules, targeting the `/v3/catalog_types` and `/v3/catalog_entries` endpoints. The v3 module for entries uses the plural name `CatalogEntriesV3` to align with the API group naming convention.