### PR TITLE
fix: replace drop_while with Enum.reject for nil-filtering in FollowUpsV2

### DIFF
--- a/lib/incident_io/follow_ups_v2.ex
+++ b/lib/incident_io/follow_ups_v2.ex
@@ -31,7 +31,7 @@ defmodule IncidentIo.FollowUpsV2 do
         incident_id: incident_id,
         incident_mode: incident_mode
       ]
-      |> Enum.drop_while(fn {_key, val} -> is_nil(val) end)
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
 
     get(
       "v2/follow_ups",


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace `Enum.drop_while/2` with `Enum.reject/2` in `IncidentIo.FollowUpsV2.list/3`

`drop_while` stops at the first non-nil element, so only leading nils are removed. If `incident_id` is provided but `incident_mode` is omitted, the nil `incident_mode` value would be forwarded as a query parameter, producing a malformed API request. `Enum.reject/2` correctly filters all nil-valued pairs regardless of position. `incidents_v1.ex` already uses the correct form; this brings `follow_ups_v2.ex` into line.

## Test plan

- [x] `mix test test/follow_ups_v2_test.exs` passes
- [x] Full `mix test` passes