### PR TITLE
fix(docs): correct copy-paste errors in @doc examples

### DIFF
--- a/lib/incident_io/incident_roles_v1.ex
+++ b/lib/incident_io/incident_roles_v1.ex
@@ -23,7 +23,7 @@ defmodule IncidentIo.IncidentRolesV1 do
 
   ## Example
 
-      IncidentIo.IncidentRolesV1.list(client, "some-incident-id")
+      IncidentIo.IncidentRolesV1.list(client)
 
   More information at: https://api-docs.incident.io/tag/Incident-Roles-V1#operation/Incident-Roles%20V1_List
   """

--- a/lib/incident_io/severities_v1.ex
+++ b/lib/incident_io/severities_v1.ex
@@ -100,7 +100,7 @@ defmodule IncidentIo.SeveritiesV1 do
   @doc """
   Update an existing severity.
 
-  Schedule body example:
+  Severity body example:
   ```elixir
   %{
     description: "Issues with **low impact**.",
@@ -111,7 +111,7 @@ defmodule IncidentIo.SeveritiesV1 do
 
   ## Example
 
-      IncidentIo.SeveritiesV1.update(client, body)
+      IncidentIo.SeveritiesV1.update(client, "some-severity-id", body)
 
   More information at: https://api-docs.incident.io/tag/Severities-V1#operation/Severities%20V1_Update
   """


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Fix `SeveritiesV1.update/3` @doc: label was "Schedule body example" (should be "Severity body example") and the example call was missing the `id` argument
- Fix `IncidentRolesV1.list/1` @doc: example incorrectly passed a second `"some-incident-id"` argument; the function only accepts a client