### PR TITLE
docs: add missing @doc annotations to Client and Json modules

### DIFF
--- a/lib/incident_io/client.ex
+++ b/lib/incident_io/client.ex
@@ -19,27 +19,23 @@ defmodule IncidentIo.Client do
   def new, do: %__MODULE__{}
 
   @doc """
-  Creates a client with a custom endpoint and no authentication.
+  Creates a client with a custom endpoint and no authentication, or with API
+  key authentication and the default endpoint.
 
   The endpoint must be a binary URL. A trailing `/` is appended automatically
   if not present.
 
-  ## Example
+  ## Examples
 
       IncidentIo.Client.new("https://api.example.com/")
+
+      IncidentIo.Client.new(%{api_key: "your-api-key"})
   """
   @spec new(binary) :: t
   def new(endpoint) when is_binary(endpoint) do
     pnew(nil, endpoint)
   end
 
-  @doc """
-  Creates a client with API key authentication and the default endpoint.
-
-  ## Example
-
-      IncidentIo.Client.new(%{api_key: "your-api-key"})
-  """
   @spec new(map()) :: t
   def new(%{api_key: _} = auth), do: %__MODULE__{auth: auth}
 

--- a/lib/incident_io/client.ex
+++ b/lib/incident_io/client.ex
@@ -8,17 +8,51 @@ defmodule IncidentIo.Client do
   @type auth :: %{api_key: binary}
   @type t :: %__MODULE__{auth: auth | nil, endpoint: binary}
 
+  @doc """
+  Creates a client with no authentication and the default endpoint.
+
+  ## Example
+
+      IncidentIo.Client.new()
+  """
   @spec new() :: t
   def new, do: %__MODULE__{}
 
+  @doc """
+  Creates a client with a custom endpoint and no authentication.
+
+  The endpoint must be a binary URL. A trailing `/` is appended automatically
+  if not present.
+
+  ## Example
+
+      IncidentIo.Client.new("https://api.example.com/")
+  """
   @spec new(binary) :: t
   def new(endpoint) when is_binary(endpoint) do
     pnew(nil, endpoint)
   end
 
+  @doc """
+  Creates a client with API key authentication and the default endpoint.
+
+  ## Example
+
+      IncidentIo.Client.new(%{api_key: "your-api-key"})
+  """
   @spec new(map()) :: t
   def new(%{api_key: _} = auth), do: %__MODULE__{auth: auth}
 
+  @doc """
+  Creates a client with API key authentication and a custom endpoint.
+
+  The endpoint must be a binary URL. A trailing `/` is appended automatically
+  if not present.
+
+  ## Example
+
+      IncidentIo.Client.new(%{api_key: "your-api-key"}, "https://api.example.com/")
+  """
   @spec new(map(), binary) :: t
   def new(%{api_key: _} = auth, endpoint) do
     pnew(auth, endpoint)

--- a/lib/incident_io/json.ex
+++ b/lib/incident_io/json.ex
@@ -1,15 +1,44 @@
 defmodule IncidentIo.Json do
   @moduledoc """
   Behaviour for JSON encoding/decoding operations.
+
+  The JSON backend defaults to `Jason` but is swappable via application config,
+  which is useful in tests when you want to use a mock:
+
+      # config/test.exs
+      config :incident_io, :json_module, IncidentIo.Json.Mock
+
+  Any replacement module must implement the `decode!/2` and `encode!/2`
+  callbacks defined by this behaviour.
   """
 
   @callback decode!(binary, keyword) :: term
   @callback encode!(term, keyword) :: binary
 
+  @doc """
+  Decodes a JSON binary into an Elixir term.
+
+  Delegates to the configured JSON module (default: `Jason`).
+
+  ## Example
+
+      IncidentIo.Json.decode!("{\"key\": \"value\"}")
+      #=> %{"key" => "value"}
+  """
   def decode!(body, opts \\ []) do
     impl().decode!(body, opts)
   end
 
+  @doc """
+  Encodes an Elixir term into a JSON binary.
+
+  Delegates to the configured JSON module (default: `Jason`).
+
+  ## Example
+
+      IncidentIo.Json.encode!(%{key: "value"})
+      #=> "{\"key\":\"value\"}"
+  """
   def encode!(data, opts \\ []) do
     impl().encode!(data, opts)
   end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `@doc` to all four `IncidentIo.Client.new/X` clauses (`new/0`, `new/1` with endpoint, `new/1` with auth map, `new/2`) — previously only `@spec` was present, so hexdocs showed no descriptions or examples
- Add `@doc` to `IncidentIo.Json.decode!/2` and `encode!/2`
- Expand `IncidentIo.Json` `@moduledoc` to document the swappable backend pattern (`Application.put_env(:incident_io, :json_module, ...)`) and how it is used in tests