### PR TITLE
docs(hexdocs): group modules by domain in sidebar

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,22 @@ defmodule IncidentIo.Mixfile do
         LICENSE: [title: "License"],
         "README.md": [title: "Overview"]
       ],
-      formatters: ["html"]
+      formatters: ["html"],
+      groups_for_modules: [
+        Core: [
+          IncidentIo,
+          IncidentIo.Client,
+          IncidentIo.Json,
+          IncidentIo.Pagination,
+          IncidentIo.Query
+        ],
+        Alerts: [~r/IncidentIo\.Alert/],
+        Catalog: [~r/IncidentIo\.Catalog/],
+        "Custom Fields": [~r/IncidentIo\.CustomField/],
+        Incidents: [~r/IncidentIo\.Incident/],
+        "On-Call": [~r/IncidentIo\.(EscalationPath|MaintenanceWindow|Schedule)/],
+        Other: [~r/IncidentIo\./]
+      ]
     ]
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `groups_for_modules` to the `docs/0` config in `mix.exs`
- The 38+ resource modules are now organised into logical sections in the hexdocs sidebar: **Core**, **Alerts**, **Catalog**, **Custom Fields**, **Incidents**, **On-Call**, and **Other**, rather than one flat alphabetical list